### PR TITLE
Rename JSDOC Reference website to URL-GEN instead of Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ console.log(myURL);
 
 ### More examples and documentation
 - [Cloudinary Documentation](https://cloudinary.com/documentation/javascript2_integration)
-- [SDK Reference](https://cloudinary.com/documentation/sdks/js/cloudinary-js-base/index.html)
+- [SDK Reference](https://cloudinary.com/documentation/sdks/js/url-gen/index.html)
 - [Use with a Frontend Framework](https://cloudinary.com/documentation/sdks/js/frontend-frameworks/index.html)
 
 ### Additional links

--- a/jsdoc.config.json
+++ b/jsdoc.config.json
@@ -30,7 +30,7 @@
     "search": true,
     "monospaceLinks": true,
     "systemColor": "#3448C5",
-    "systemName": "Cloudinary Base SDK",
+    "systemName": "Cloudinary URL-GEN (JS)",
     "systemLogo": "./__DOCS__/resources/navLogo.png",
     "systemSummary": "@cloudinary/url-gen",
     "favicon": "./__DOCS__/resources/favico.png",


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen
- Rename JSDOC Reference website to URL-GEN instead of Base