### PR TITLE
Add getConfig and remove un-needed property in Cloudinary

### DIFF
--- a/src/instance/Cloudinary.ts
+++ b/src/instance/Cloudinary.ts
@@ -4,8 +4,7 @@ import {CloudinaryVideo} from "../assets/CloudinaryVideo.js";
 
 
 class Cloudinary {
-  CloudinaryImage: typeof CloudinaryImage;
-  cloudinaryConfig: ICloudinaryConfigurations;
+  private cloudinaryConfig: ICloudinaryConfigurations;
 
   constructor(cloudinaryConfig?: ICloudinaryConfigurations) {
     if (cloudinaryConfig) {
@@ -24,6 +23,10 @@ class Cloudinary {
   setConfig(cloudinaryConfig: ICloudinaryConfigurations):this {
     this.cloudinaryConfig = cloudinaryConfig;
     return this;
+  }
+
+  getConfig() {
+    return this.cloudinaryConfig;
   }
 
   extendConfig():void {


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen
- Remove un-used property CloudinaryImage from Cloudinary instance
- set the config as a private member
- add a getter for the config.
