### PR TITLE
simplify jest resolver

### DIFF
--- a/src/internal/utils/jest-ts-resolver.cjs
+++ b/src/internal/utils/jest-ts-resolver.cjs
@@ -1,32 +1,15 @@
-let defaultResolver;
-
 /**
- *
- * @return {(path: Config.Path, options: ResolverOptions) => Config.Path}
+ * Jest can’t find files with a .js extension. We use this resolver to catch that error and replace the files with a
+ * .ts extension.
  */
-async function requireDefaultResolver() {
-  if (!defaultResolver) {
-    try {
-      defaultResolver = await import(`jest-resolve/build/defaultResolver`).default;
-    } catch (error) {
-      defaultResolver = await import(`jest-resolve/build/default_resolver`).default;
-    }
-  }
-
-  return defaultResolver;
-}
-
-
 module.exports = (request, options) => {
-  let {basedir, defaultResolver, extensions} = options;
-
-  if (!defaultResolver) {
-    defaultResolver = requireDefaultResolver();
-  }
+  // Jest's default resolver
+  const {defaultResolver} = options;
 
   try {
     return defaultResolver(request, options);
+    // if default resolver fails we replace file extension from .js to .ts
   } catch (e) {
     return defaultResolver(request.replace(/\.js$/, '.ts'), options);
   }
-}
+};


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
Jest can’t find files with a .js extension. We use this resolver to catch that error and replace the files with a .ts extension.

