### PR TITLE
Add support for string gravity of pad actions

### DIFF
--- a/__TESTS__/unit/actions/Resize.test.ts
+++ b/__TESTS__/unit/actions/Resize.test.ts
@@ -17,4 +17,9 @@ describe('Tests for Transformation Action -- Resize', () => {
     const url = getImageWithResize(Resize.scale().width(Expression.expression('100 + 5')), 'url');
     expect(url).toContain('c_scale,w_100_add_5');
   });
+
+  it('Resize with gravity', () => {
+    const url = getImageWithResize(Resize.pad().width(100).gravity('west'), 'url');
+    expect(url).toContain('c_pad,g_west,w_100');
+  });
 });

--- a/__TESTS__/unit/fromJson.test.ts
+++ b/__TESTS__/unit/fromJson.test.ts
@@ -17,7 +17,7 @@ describe('fromJson', () => {
       {actionType: 'minimumPad', dimensions: {width: 100}, relative: true, gravity: 'south', x: 3, y:4, background: 'white'}
     ]);
 
-    expect(transformation.toString()).toStrictEqual('c_scale,w_100/c_fit,fl_relative,h_200/c_limit,fl_relative,h_200/c_mfit,fl_region_relative,w_100/c_crop,fl_region_relative,g_north_east,w_100,y_3,z_7/c_fill,fl_relative,g_south,w_100,x_4,y_5/c_lfill,fl_relative,g_south,w_100,x_4,y_5/c_thumb,fl_relative,g_south,w_100,z_4/b_white,c_pad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_lpad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_mpad,fl_relative,g_south,w_100,x_3,y_4');
+    expect(transformation.toString()).toStrictEqual('ar_7.0,c_scale,w_100/ar_16:9,c_fit,fl_relative,h_200/c_limit,fl_ignore_aspect_ratio,fl_relative,h_200/c_mfit,fl_region_relative,w_100/c_crop,fl_region_relative,g_north_east,w_100,y_3,z_7/c_fill,fl_relative,g_south,w_100,x_4,y_5/c_lfill,fl_relative,g_south,w_100,x_4,y_5/c_thumb,fl_relative,g_south,w_100,z_4/b_white,c_pad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_lpad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_mpad,fl_relative,g_south,w_100,x_3,y_4');
   });
 
   it('should generate an error for array that includes an unsupported action', function () {

--- a/__TESTS__/unit/fromJson.test.ts
+++ b/__TESTS__/unit/fromJson.test.ts
@@ -17,7 +17,7 @@ describe('fromJson', () => {
       {actionType: 'minimumPad', dimensions: {width: 100}, relative: true, gravity: 'south', x: 3, y:4, background: 'white'}
     ]);
 
-    expect(transformation.toString()).toStrictEqual('c_scale,w_100/c_fit,fl_relative,h_200/c_limit,fl_relative,h_200/c_mfit,fl_region_relative,w_100/c_crop,fl_region_relative,g_north_east,w_100,y_3,z_7/c_fill,fl_relative,g_south,w_100,x_4,y_5/c_lfill,fl_relative,g_south,w_100,x_4,y_5/c_thumb,fl_relative,g_south,w_100,z_4/b_white,c_pad,fl_relative,south_,w_100,x_3,y_4/b_white,c_lpad,fl_relative,south_,w_100,x_3,y_4/b_white,c_mpad,fl_relative,south_,w_100,x_3,y_4');
+    expect(transformation.toString()).toStrictEqual('c_scale,w_100/c_fit,fl_relative,h_200/c_limit,fl_relative,h_200/c_mfit,fl_region_relative,w_100/c_crop,fl_region_relative,g_north_east,w_100,y_3,z_7/c_fill,fl_relative,g_south,w_100,x_4,y_5/c_lfill,fl_relative,g_south,w_100,x_4,y_5/c_thumb,fl_relative,g_south,w_100,z_4/b_white,c_pad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_lpad,fl_relative,g_south,w_100,x_3,y_4/b_white,c_mpad,fl_relative,g_south,w_100,x_3,y_4');
   });
 
   it('should generate an error for array that includes an unsupported action', function () {

--- a/__TESTS__/unit/toJson.test.ts
+++ b/__TESTS__/unit/toJson.test.ts
@@ -2,12 +2,11 @@ import {Transformation} from '../../src';
 import {Delivery, Resize} from "../../src/actions";
 import {UnsupportedError} from "../../src/internal/utils/unsupportedError";
 import {Action} from "../../src/internal/Action";
-import {AspectRatio, Gravity} from "../../src/qualifiers";
+import {AspectRatio} from "../../src/qualifiers";
 import {Format} from "../../src/qualifiers/format";
 import {Progressive} from "../../src/qualifiers/progressive";
 import {Quality} from "../../src/qualifiers/quality";
 import {ChromaSubSampling} from "../../src/qualifiers";
-import {CompassQualifier} from "../../src/qualifiers/gravity/qualifiers/compass/CompassQualifier";
 
 describe('Transformation.toJson()', () => {
   it('scale', () => {

--- a/__TESTS__/unit/toJson.test.ts
+++ b/__TESTS__/unit/toJson.test.ts
@@ -2,8 +2,6 @@ import {Transformation} from '../../src';
 import {Resize} from "../../src/actions";
 import {UnsupportedError} from "../../src/internal/utils/unsupportedError";
 import {Action} from "../../src/internal/Action";
-import {Gravity} from "../../src/qualifiers";
-import {CompassQualifier} from "../../src/qualifiers/gravity/qualifiers/compass/CompassQualifier";
 
 describe('Transformation.toJson()', () => {
   it('scale', () => {
@@ -29,9 +27,9 @@ describe('Transformation.toJson()', () => {
       .addAction(Resize.fill(200).x(3).y(4).gravity('south'))
       .addAction(Resize.limitFill(200).x(3).y(4).gravity('south'))
       .addAction(Resize.thumbnail(100).gravity('south').zoom(4))
-      .addAction(Resize.pad(100).gravity(Gravity.compass(new CompassQualifier('south'))).offsetX(3).offsetY(4))
-      .addAction(Resize.limitPad(100).gravity(Gravity.compass(new CompassQualifier('south'))).offsetX(3).offsetY(4))
-      .addAction(Resize.minimumPad(100).gravity(Gravity.compass(new CompassQualifier('south'))).offsetX(3).offsetY(4));
+      .addAction(Resize.pad(100).gravity('south').offsetX(3).offsetY(4))
+      .addAction(Resize.limitPad(100).gravity('south').offsetX(3).offsetY(4))
+      .addAction(Resize.minimumPad(100).gravity('south').offsetX(3).offsetY(4));
     expect(transformation.toJson()).toStrictEqual([
       {
         "actionType": "scale",

--- a/src/actions/resize/ResizeAdvancedAction.ts
+++ b/src/actions/resize/ResizeAdvancedAction.ts
@@ -17,7 +17,6 @@ class ResizeAdvancedAction extends ResizeSimpleAction {
    * @param {Qualifiers.Gravity} gravity
    */
   gravity(gravity: IGravity | IShortenGravity): this {
-
     if(typeof gravity === "string") {
       this._actionModel.gravity = gravity;
       return this.addQualifier(new Qualifier('g', gravity));

--- a/src/actions/resize/ResizePadAction.ts
+++ b/src/actions/resize/ResizePadAction.ts
@@ -22,11 +22,6 @@ class ResizePadAction<GravityType extends IGravity> extends ResizeAdvancedAction
     return this.addQualifier(backgroundQualifier);
   }
 
-  gravity(direction: GravityType): this {
-    this._actionModel.gravity = `${direction.qualifierValue || direction}`;
-    return this.addQualifier(direction);
-  }
-
   /**
    * @description Horizontal position for custom-coordinates based padding.
    * @param {number} x The x position.


### PR DESCRIPTION
This adds the option to pass string to pad.gravity like so:
`.addAction(Resize.pad(100).gravity('south');`

Right now, must do this:
`.addAction(Resize.pad(100).gravity(Gravity.compass(Compass.south()))`
