### PR TITLE
Add CloudConfig exports to root level

### DIFF
--- a/__TESTS__/unit/index.test.ts
+++ b/__TESTS__/unit/index.test.ts
@@ -1,10 +1,13 @@
 import {
+  CloudConfig,
   CloudinaryImage,
   CloudinaryVideo,
   Transformation,
   Cloudinary,
   Qualifiers,
-  Actions
+  Actions,
+  CloudinaryConfig,
+  URLConfig
 } from '../../src/index';
 
 describe('Ensures index exports correctly', () => {
@@ -15,6 +18,8 @@ describe('Ensures index exports correctly', () => {
     expect(Cloudinary).toBeDefined();
     expect(Qualifiers).toBeDefined();
     expect(Actions).toBeDefined();
+    expect(CloudConfig).toBeDefined();
+    expect(URLConfig).toBeDefined();
+    expect(CloudinaryConfig).toBeDefined();
   });
 });
-

--- a/src/config/CloudConfig.ts
+++ b/src/config/CloudConfig.ts
@@ -51,5 +51,5 @@ class CloudConfig extends Config implements ICloudConfig {
   }
 }
 
-
+export {CloudConfig};
 export default CloudConfig;

--- a/src/config/CloudConfig.ts
+++ b/src/config/CloudConfig.ts
@@ -51,5 +51,4 @@ class CloudConfig extends Config implements ICloudConfig {
   }
 }
 
-export {CloudConfig};
 export default CloudConfig;

--- a/src/config/CloudinaryConfig.ts
+++ b/src/config/CloudinaryConfig.ts
@@ -39,5 +39,4 @@ class CloudinaryConfig {
   }
 }
 
-export {CloudinaryConfig};
 export default CloudinaryConfig;

--- a/src/config/CloudinaryConfig.ts
+++ b/src/config/CloudinaryConfig.ts
@@ -39,5 +39,5 @@ class CloudinaryConfig {
   }
 }
 
-
+export {CloudinaryConfig};
 export default CloudinaryConfig;

--- a/src/config/URLConfig.ts
+++ b/src/config/URLConfig.ts
@@ -103,5 +103,4 @@ class URLConfig extends Config implements IURLConfig {
   }
 }
 
-export {URLConfig};
 export default URLConfig;

--- a/src/config/URLConfig.ts
+++ b/src/config/URLConfig.ts
@@ -103,5 +103,5 @@ class URLConfig extends Config implements IURLConfig {
   }
 }
 
-
+export {URLConfig};
 export default URLConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+export {URLConfig} from "./config/URLConfig.js";
+export {CloudConfig} from "./config/CloudConfig.js";
+export {CloudinaryConfig} from "./config/CloudinaryConfig.js";
 export {Transformation} from "./transformation/Transformation.js";
 export {ImageTransformation} from "./transformation/ImageTransformation.js";
 export {VideoTransformation} from "./transformation/VideoTransformation.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-export {URLConfig} from "./config/URLConfig.js";
-export {CloudConfig} from "./config/CloudConfig.js";
-export {CloudinaryConfig} from "./config/CloudinaryConfig.js";
+import URLConfig from "./config/URLConfig.js";
+import CloudConfig from "./config/CloudConfig.js";
+import CloudinaryConfig from "./config/CloudinaryConfig.js";
+
 export {Transformation} from "./transformation/Transformation.js";
 export {ImageTransformation} from "./transformation/ImageTransformation.js";
 export {VideoTransformation} from "./transformation/VideoTransformation.js";
@@ -12,3 +13,5 @@ export {Cloudinary} from "./instance/Cloudinary.js";
 export {createCloudinaryLegacyURL} from "./backwards/createCloudinaryLegacyURL.js";
 export * as Actions from './actions.js';
 export * as Qualifiers from './qualifiers.js';
+
+export {URLConfig, CloudConfig, CloudinaryConfig};


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
Add CloudConfig and URLConfig to root level exports to remove warnings from Angular 
https://stackoverflow.com/questions/46446080/what-is-a-deep-import-in-angular-4-context


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
