### PR TITLE
Add ConcatenateAction.fromJson()

### DIFF
--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
@@ -88,7 +88,7 @@ const bundleSizeTestCases:ITestCase[] = [
   },
   {
     name: 'Import All Actions',
-    sizeLimitInKB: 42,
+    sizeLimitInKB: 43,
     importsArray: [
       importFromPackage('Actions')
     ]

--- a/__TESTS__/unit/fromJson/concatenate.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/concatenate.fromJson.test.ts
@@ -1,0 +1,21 @@
+import {fromJson} from "../../../src/internal/fromJson";
+import {IConcatenateActionModel} from "../../../src/internal/models/IConcatenateActionModel";
+
+describe('concatenate.fromJson', () => {
+  it('Should generate ConcatenateAction from model', ()=>{
+    const concatenateModel: IConcatenateActionModel = {
+      actionType: 'concatenate',
+      source: {
+        qualifierType: 'videoSource',
+        sourceType: 'video',
+        publicId: 'dog'
+      },
+      prepend: true,
+      duration: 1
+    };
+
+    const transformation = fromJson([concatenateModel]);
+
+    expect(transformation.toString()).toStrictEqual('du_1,fl_splice,l_video:dog/fl_layer_apply,so_0');
+  });
+});

--- a/src/actions/videoEdit/ConcatenateAction.ts
+++ b/src/actions/videoEdit/ConcatenateAction.ts
@@ -3,6 +3,9 @@ import {Transformation} from "../../transformation/Transformation.js";
 import {VideoSource} from "../../qualifiers/source/sourceTypes/VideoSource.js";
 import {ImageSource} from "../../qualifiers/source/sourceTypes/ImageSource.js";
 import {FetchSource} from "../../qualifiers/source/sourceTypes/FetchSource.js";
+import {IActionModel} from "../../internal/models/IActionModel.js";
+import {IConcatenateActionModel} from "../../internal/models/IConcatenateActionModel.js";
+import {ITransformationFromJson} from "../../internal/models/IHasFromJson.js";
 
 /**
  * @description Class for Concatenating another video.
@@ -17,6 +20,7 @@ class ConcatenateAction extends Action {
   private _prepend: boolean;
   private _duration: number;
   private _transition: VideoSource;
+  protected _actionModel: IConcatenateActionModel;
 
   /**
    *
@@ -25,6 +29,11 @@ class ConcatenateAction extends Action {
    */
   constructor(source: VideoSource | ImageSource | FetchSource) {
     super();
+    this._actionModel = {
+      actionType: 'concatenate',
+      source: { sourceType: 'video' }
+    };
+
     this.concatSource = source;
   }
 
@@ -123,6 +132,28 @@ class ConcatenateAction extends Action {
       concatSourceTx.toString(),
       close
     ].filter((a) => a).join('/');
+  }
+
+  static fromJson(actionModel: IActionModel, transformationFromJson: ITransformationFromJson): ConcatenateAction {
+    const {source, transition, prepend, duration} = (actionModel as IConcatenateActionModel);
+
+    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [actionModel])
+    // This allows the inheriting classes to determine the class to be created
+    // @ts-ignore
+    const result = new this(VideoSource.fromJson(source, transformationFromJson));
+    if (transition){
+      result.transition(VideoSource.fromJson(transition, transformationFromJson));
+    }
+
+    if (prepend){
+      result.prepend();
+    }
+
+    if (duration){
+      result.duration(duration);
+    }
+
+    return result;
   }
 }
 

--- a/src/internal/fromJson.ts
+++ b/src/internal/fromJson.ts
@@ -6,7 +6,7 @@ import {IActionModel} from "./models/IActionModel.js";
 import {Action} from "./Action.js";
 import {IErrorObject} from "./models/IErrorObject.js";
 import {createUnsupportedError} from "./utils/unsupportedError.js";
-import {IHasFromJson} from "./models/IHasFromJson.js";
+import {IHasFromJson, ITransformationFromJson} from "./models/IHasFromJson.js";
 import {ResizeMinimumFitAction} from "../actions/resize/ResizeMinimumFitAction.js";
 import {ResizeCropAction} from "../actions/resize/ResizeCropAction.js";
 import {ResizeFillAction} from "../actions/resize/ResizeFillAction.js";
@@ -40,6 +40,7 @@ import {Pixelate} from "../actions/effect/pixelate/Pixelate.js";
 import {BlurAction} from "../actions/effect/blur/Blur.js";
 import {ImproveAction} from "../actions/adjust/ImproveAction.js";
 import {DeliveryDPRAction} from "../actions/delivery/DeliveryDPRAction.js";
+import ConcatenateAction from "../actions/videoEdit/ConcatenateAction.js";
 
 const ActionModelMap: Record<string, IHasFromJson> = {
   scale: ResizeScaleAction,
@@ -90,7 +91,8 @@ const ActionModelMap: Record<string, IHasFromJson> = {
   dpr: DeliveryDPRAction,
   contrast: EffectActionWithLevel,
   brightness: EffectActionWithLevel,
-  gamma: EffectActionWithLevel
+  gamma: EffectActionWithLevel,
+  concatenate: ConcatenateAction
 };
 
 /**
@@ -105,7 +107,7 @@ function actions(actionModels: IActionModel[]): Action[] {
       throw createUnsupportedError(`unsupported action ${actionModel.actionType}`);
     }
 
-    return actionClass.fromJson(actionModel);
+    return actionClass.fromJson(actionModel, fromJson as ITransformationFromJson);
   });
 }
 

--- a/src/internal/models/IConcatenateActionModel.ts
+++ b/src/internal/models/IConcatenateActionModel.ts
@@ -1,0 +1,10 @@
+import {IActionModel} from "./IActionModel.js";
+import {IVideoSourceModel} from "./IVideoSourceModel.js";
+import {ISourceModel} from "./ISourceModel.js";
+
+export interface IConcatenateActionModel extends IActionModel{
+  source: ISourceModel; // TODO: add and update source: IVideoSourceModel | IImageSourceModel | IFetchSourceModel
+  transition?: IVideoSourceModel,
+  prepend?: boolean;
+  duration?: number;
+}

--- a/src/internal/models/IHasFromJson.ts
+++ b/src/internal/models/IHasFromJson.ts
@@ -1,8 +1,9 @@
 import {IActionModel} from "./IActionModel.js";
 import {Action} from "../Action.js";
+import {Transformation} from "../../transformation/Transformation.js";
 
-interface IHasFromJson {
-  fromJson: (actionModel: IActionModel) => Action;
+export type ITransformationFromJson = (actionModels: IActionModel[]) => Transformation;
+
+export interface IHasFromJson {
+  fromJson: (actionModel: IActionModel, transformationFromJson?: ITransformationFromJson) => Action;
 }
-
-export {IHasFromJson};

--- a/src/internal/models/IQualifierModel.ts
+++ b/src/internal/models/IQualifierModel.ts
@@ -1,0 +1,13 @@
+export interface IQualifierModel {
+  qualifierType?: string;
+  [x: string]: unknown;
+}
+
+/**
+ * Validates obj is an instance of IQualifierModel
+ * @param obj
+ */
+export function isIQualifierModel(obj: unknown): obj is IQualifierModel{
+  const qualifierModel = obj as IQualifierModel;
+  return ('qualifierType' in qualifierModel);
+}

--- a/src/internal/models/ISourceModel.ts
+++ b/src/internal/models/ISourceModel.ts
@@ -1,0 +1,5 @@
+import {IQualifierModel} from "./IQualifierModel.js";
+
+export interface ISourceModel extends IQualifierModel {
+  sourceType: string;
+}

--- a/src/internal/models/IVideoSourceModel.ts
+++ b/src/internal/models/IVideoSourceModel.ts
@@ -1,0 +1,9 @@
+import {ISourceModel} from "./ISourceModel.js";
+import {IVideoTransformationModel} from "./IVideoTransformationModel.js";
+
+export interface IVideoSourceModel extends ISourceModel {
+  qualifierType: "videoSource";
+  sourceType: "video";
+  publicId: string;
+  transformation?: IVideoTransformationModel;
+}

--- a/src/internal/models/IVideoTransformationModel.ts
+++ b/src/internal/models/IVideoTransformationModel.ts
@@ -1,0 +1,5 @@
+import {IActionModel} from "./IActionModel.js";
+
+export interface IVideoTransformationModel{
+  actions: IActionModel[]; //
+}

--- a/src/qualifiers/source/sourceTypes/VideoSource.ts
+++ b/src/qualifiers/source/sourceTypes/VideoSource.ts
@@ -1,4 +1,6 @@
 import {BaseSource} from "../BaseSource.js";
+import {IVideoSourceModel} from "../../../internal/models/IVideoSourceModel.js";
+import {ITransformationFromJson} from "../../../internal/models/IHasFromJson.js";
 
 /**
  * @memberOf Qualifiers.Source
@@ -34,6 +36,21 @@ class VideoSource extends BaseSource {
     const encodedPublicID = this.encodeAssetPublicID(this._publicID);
 
     return `${layerType}_video:${encodedPublicID}`;
+  }
+
+  static fromJson(qualifierModel: IVideoSourceModel, transformationFromJson: ITransformationFromJson): VideoSource {
+    const videoSourceModel = qualifierModel as IVideoSourceModel;
+    const {publicId, transformation} = videoSourceModel;
+
+    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [qualifierModel])
+    // This allows the inheriting classes to determine the class to be created
+    // @ts-ignore
+    const result = new this(publicId);
+    if (transformation) {
+      result.transformation(transformationFromJson(transformation.actions));
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
This pr adds fromJson support to Concatenate.
It will be used as base for adding fromJson support to more video.edit actions.

Reviewer please note: I've added a new parameter to the internal fromJson function: tranformationFromJson.
It is used by actions that have internal transformations (like Concatenate) to generate a transformation from json.
Adding the parameter prevents the need to import the function and all it's dependencies inside the Concatenate action or it's source qualifier.