### PR TITLE
Fix build:docs script by using bash instead of node's execSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "bash ./scripts/build.sh",
     "build:ESM": "tsc --project tsconfig.json --outDir dist --declaration true",
     "build:rollup": "rollup -c",
-    "build:docs": "node ./scripts/buildDocs.js",
+    "build:docs": "bash ./scripts/buildDocs.sh",
     "build:entryPoints": "ts-node ./scripts/createEntrypoints.ts",
     "build:injectPackageVersion": "ts-node ./scripts/injectPackageVersionToDistFiles.ts",
     "build:updatePackageExports": "ts-node scripts/updatePackageJsonExports.ts",

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -1,0 +1,7 @@
+set -e;
+
+node ./scripts/updateInjectVersionSemver.js
+(cd ./__DOCS__/JSDocTemplate && grunt)
+jsdoc -u ./__DOCS__/examples --configure jsdoc.config.json --verbose --destination public/docs/
+cp __DOCS__/resources/customStyles.css public/docs/
+cp __DOCS__/resources/injectVersionSemver.js public/docs/

--- a/scripts/updateInjectVersionSemver.js
+++ b/scripts/updateInjectVersionSemver.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-const { execSync } = require('child_process');
 const fs = require('fs');
 const pkg = require('../package.json');
 
@@ -12,10 +11,3 @@ $('.branding-logo').html(content + ' - ${pkg.version}');
 $('.copyright').html('Copyright © ' + new Date().getFullYear()  + ' Cloudinary.com');
 `;
 fs.writeFileSync('__DOCS__/resources/injectVersionSemver.js', data);
-
-execSync(`
-  (cd ./__DOCS__/JSDocTemplate && grunt) && 
-  jsdoc -u ./__DOCS__/examples --configure jsdoc.config.json --verbose --destination public/docs/ && 
-  cp __DOCS__/resources/customStyles.css public/docs/ && 
-  cp __DOCS__/resources/injectVersionSemver.js public/docs/
-`, {stdio: 'inherit'});


### PR DESCRIPTION
This pr fixes an issue where the build:docs script fails.
jsDoc fails when runned in an execSync but works when manually executed, so I moved it to a bash script, which fixed the issue.