### PR TITLE
Change library name for umd bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default [
       {
         file: 'dist/bundles/umd/base.js',
         format: 'umd',
-        name: 'CloudinaryBaseSDK',
+        name: 'CLD_URL_GEN',
       },
     ],
     plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default [
       {
         file: 'dist/bundles/umd/base.js',
         format: 'umd',
-        name: 'CLD_URL_GEN',
+        name: 'CldUrlGen',
       },
     ],
     plugins: [


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
Change the old BaseSDK library name to CLD_URL_GEN.

I'm very open to naming suggestions.