### PR TITLE
Update travis.yml to run tests on node 12 & node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "12"
+  - "14"
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
Our build failed on node 14 due to betterDocs issue, but we did not catch it on travis, so added node 14 to travis.yml