### PR TITLE
fixed betterdocs version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/webpack": "^4.41.21",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
-    "better-docs": "^2.3.0",
+    "better-docs": "2.3.2",
     "bootstrap": "^3.3.7",
     "bundlewatch": "^0.2.6",
     "cheerio": "^0.22.0",


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
We're getting typescript errors when building the docs. This was related to a change in betterdocs. 
Fixing the version resolves those issues. 

