### PR TITLE
Allow adding external authTokens

### DIFF
--- a/__TESTS__/unit/analytics/analytics.node.test.ts
+++ b/__TESTS__/unit/analytics/analytics.node.test.ts
@@ -169,4 +169,40 @@ describe('Add analytics to a regular URL', () => {
       }
     })).toBe("https://res.cloudinary.com/demo/image/upload/sample%3Fparam%3Dtest");
   });
+
+  it('Should not include analytics when authToken is provided', () => {
+    const cldImage = createNewImageWithAnalytics('sample');
+    cldImage.sign();
+    cldImage.setExplicitAuthToken('someToken');
+    // AZ -> Algo A, SDK Code is Z
+    // Alh -> 1.24.0 from package.json
+    // AM -> 12.0.0 Underlying tech
+    // A -> responsive
+    expect(cldImage.toURL({
+      trackedAnalytics: {
+        sdkCode: 'Z',
+        sdkSemver: '1.24.0',
+        techVersion: '12.0.0',
+        responsive: true
+      }
+    })).toBe("https://res.cloudinary.com/demo/image/upload/sample?__cld_token__=someToken");
+  });
+
+  it('Should include analytics when signature is provided', () => {
+    const cldImage = createNewImageWithAnalytics('sample');
+    cldImage.sign();
+    cldImage.setSignature('someSignature');
+    // AZ -> Algo A, SDK Code is Z
+    // Alh -> 1.24.0 from package.json
+    // AM -> 12.0.0 Underlying tech
+    // A -> responsive
+    expect(cldImage.toURL({
+      trackedAnalytics: {
+        sdkCode: 'Z',
+        sdkSemver: '1.24.0',
+        techVersion: '12.0.0',
+        responsive: true
+      }
+    })).toBe(`https://res.cloudinary.com/demo/image/upload/s--someSignature--/sample?_a=AZAlhAMA`);
+  });
 });

--- a/__TESTS__/unit/url/url.test.ts
+++ b/__TESTS__/unit/url/url.test.ts
@@ -88,10 +88,25 @@ describe('Tests for URL configuration', () => {
     const signature = "some-signature";
 
     image.setSignature(signature);
+    image.sign();
+
     //image.signature(signature)
     image.resize(Resize.crop().width(100));
     const url = image.toURL();
 
     expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/s--${signature}--/c_crop,w_100/sample`);
+  });
+
+  it('Should support an explicit auth token', () => {
+    const image = createNewImage('sample');
+    const authToken = "some-auth-token";
+
+    image.setExplicitAuthToken(authToken);
+    image.sign();
+
+    image.resize(Resize.crop().width(100));
+    const url = image.toURL();
+
+    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/c_crop,w_100/sample?__cld_token__=${authToken}`);
   });
 });


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
This PR adds the ability to pass an external, pre-calculated authToken to the SDK.


#### Use case
The use case for this PR is using the SDK on the client side, while generating the authToken on some backend server.

## What was done in this PR?
- Add setExplicitAuthToken as a public API of the CloudinaryFile (affecting images, videos, medias etc.)
- Implement the missing `sign()` method
- Fix a bug where you could sign a URL simply by providing a signature, without calling sign() - it is now required to call sign() as intended.
- Add validations for the usage of signatures and authTokens (The SDK will throw when invalid combinations are found)
- Refactor the logic for appending query params to the URL to a new function.
- Disable analytics in case the URL contains any query param (As well as if it appears in the publicID)
- Added tests (obviously!)


## Discussion points to close before merging

- [ ] Our public function is called `sign()` while our internal flag is called `signURL` - this seems confusing from a maintenance point of view.
- [ ] We're currently URL-encoding publicIDs, turning `?` into `%3F` - this looks like a bug for public IDs that actually need the query param intact (such as for auto-upload) - I've added some code that keeps the behavior as it is today, but I'd like a second glance on this solution (This actual issue, of encoding publicIDs, will need to be addressed in a separate PR)
- [ ] I'm not content about the names `authToken` and `explicitAuthToken` , it sounds like `authTokenConfig` and `authToken` are better names - I'd love to hear opinions here.


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
