### PR TITLE
Align transcode.toAnimated with the spec

### DIFF
--- a/.code-generation/config.js
+++ b/.code-generation/config.js
@@ -61,8 +61,8 @@ module.exports = {
         close: '',
       }
     },
-    unsupportedTxParams: ['fl_waveform', 'fl_animated', 'e_theme', 'af_'],
-    unsupportedSyntaxList: ['.stroke(', '.textFit(', 'Animated.edit', '.RoundCorners(', 'getVideoFrame', '.transcode(']
+    unsupportedTxParams: ['fl_waveform', 'e_theme', 'af_'],
+    unsupportedSyntaxList: ['.stroke(', '.textFit(', 'Animated.edit', '.RoundCorners(', 'getVideoFrame']
   },
   "overwrites": {
     qualifiers: {

--- a/__TESTS__/unit/actions/Transcode.test.ts
+++ b/__TESTS__/unit/actions/Transcode.test.ts
@@ -159,24 +159,24 @@ describe('Tests for Transformation Action -- Transcode', () => {
     expect(url).toBe('https://res.cloudinary.com/demo/video/upload/f_webp,fl_animated,fl_awebp/sample');
   });
 
-  it('Creates a cloudinaryURL with toAnimated and delay', () => {
+  it('Creates a cloudinaryURL with toAnimated', () => {
     const url = createNewVideo('sample')
       .transcode(Transcode
-        .toAnimated('gif').delay(20))
+        .toAnimated('gif'))
       .setPublicID('sample')
       .toURL();
 
-    expect(url).toBe('https://res.cloudinary.com/demo/video/upload/dl_20,f_gif,fl_animated/sample');
+    expect(url).toBe('https://res.cloudinary.com/demo/video/upload/f_gif,fl_animated/sample');
   });
 
-  it('Creates a cloudinaryURL with toAnimated, delay, sampling', () => {
+  it('Creates a cloudinaryURL with toAnimated, sampling', () => {
     const url = createNewVideo('sample')
       .transcode(Transcode
-        .toAnimated(AnimatedFormat.gif()).delay(20).sampling('4s'))
+        .toAnimated(AnimatedFormat.gif()).sampling('4s'))
       .setPublicID('sample')
       .toURL();
 
-    expect(url).toBe('https://res.cloudinary.com/demo/video/upload/dl_20,f_gif,fl_animated,vs_4s/sample');
+    expect(url).toBe('https://res.cloudinary.com/demo/video/upload/f_gif,fl_animated,vs_4s/sample');
   });
 
   it('Tests for simple videoCodec', () => {


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
Aligns transcode.toAnimated with our spec

- Remove Delay (moved to Animated.edit) and fix tests.
- Remove transcode from unsupported syntax (it's now supported)


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
