### PR TITLE
Fix transformation-builder-sdk imports

### DIFF
--- a/__TESTS__/unit/testBuild.test.ts
+++ b/__TESTS__/unit/testBuild.test.ts
@@ -1,0 +1,25 @@
+import {
+  CloudConfig,
+  CloudinaryImage,
+  CloudinaryVideo,
+  Transformation,
+  Cloudinary,
+  Qualifiers,
+  Actions,
+  CloudinaryConfig,
+  URLConfig
+} from '../../dist/index';
+
+describe('Ensures index exports correctly', () => {
+  it('Exports correctly', () => {
+    expect(CloudinaryImage).toBeDefined();
+    expect(CloudinaryVideo).toBeDefined();
+    expect(Transformation).toBeDefined();
+    expect(Cloudinary).toBeDefined();
+    expect(Qualifiers).toBeDefined();
+    expect(Actions).toBeDefined();
+    expect(CloudConfig).toBeDefined();
+    expect(URLConfig).toBeDefined();
+    expect(CloudinaryConfig).toBeDefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "description": "",
   "scripts": {
-    "test": "npm run test:types && npm run build && jest --coverage --reporters default &&  npm run test:size",
+    "test": "npm run build && npm run test:types && npm run build && jest --coverage --reporters default &&  npm run test:size",
     "test:size": "ts-node -O '{\"module\":\"CommonJS\"}' __TESTS_BUNDLE_SIZE__/bin/bin.ts",
     "test:comp": "node ./scripts/updateCompliationTests.js && jest __TESTS__/compilationsOutput.test.ts  --coverage",
     "test:comp:service": "ts-node -O '{\"module\":\"CommonJS\"}' devTools/sanity/index.ts && jest __TESTS__/compilation.test.ts",

--- a/src/actions/adjust.ts
+++ b/src/actions/adjust.ts
@@ -1,9 +1,9 @@
-import {Adjust} from "@cloudinary/transformation-builder-sdk/actions.js";
+import {Adjust} from "@cloudinary/transformation-builder-sdk/actions";
 import {
   IAdjustAction, brightness, viesusCorrect, opacity, red, sharpen, improve, saturation,
   contrast, gamma, green, blue, brightnessHSB, hue, autoBrightness, autoColor,
   autoContrast, vibrance, unsharpMask, opacityThreshold, replaceColor, recolor, fillLight, by3dLut, tint
-} from "@cloudinary/transformation-builder-sdk/actions/adjust.js";
+} from "@cloudinary/transformation-builder-sdk/actions/adjust";
 
 export {IAdjustAction, Adjust, brightness, viesusCorrect, opacity, red, sharpen, improve, saturation,
   contrast, gamma, green, blue, brightnessHSB, hue, autoBrightness, autoColor,

--- a/src/actions/delivery.ts
+++ b/src/actions/delivery.ts
@@ -1,5 +1,5 @@
 import {IDeliveryAction, Delivery, format, dpr, quality, density, defaultImage, colorSpace, colorSpaceFromICC}
-  from "@cloudinary/transformation-builder-sdk/actions/delivery.js";
+  from "@cloudinary/transformation-builder-sdk/actions/delivery";
 
 export {IDeliveryAction, Delivery, format, dpr, quality, density, defaultImage, colorSpace, colorSpaceFromICC};
 

--- a/src/actions/rotate.ts
+++ b/src/actions/rotate.ts
@@ -1,2 +1,2 @@
-import {Rotate, byAngle, mode} from "@cloudinary/transformation-builder-sdk/actions/rotate.js";
+import {Rotate, byAngle, mode} from "@cloudinary/transformation-builder-sdk/actions/rotate";
 export {Rotate, byAngle, mode};

--- a/src/assets/CloudinaryImage.ts
+++ b/src/assets/CloudinaryImage.ts
@@ -1,4 +1,4 @@
-import {ImageTransformation} from "@cloudinary/transformation-builder-sdk/transformation/ImageTransformation.js";
+import {ImageTransformation} from "@cloudinary/transformation-builder-sdk/transformation/ImageTransformation";
 import {CloudinaryTransformable} from "./CloudinaryTransformable.js";
 import ICloudConfig from "../config/interfaces/Config/ICloudConfig.js";
 import IURLConfig from "../config/interfaces/Config/IURLConfig.js";

--- a/src/qualifiers/FontAntialias.ts
+++ b/src/qualifiers/FontAntialias.ts
@@ -6,7 +6,7 @@ import {
   fast,
   none,
   good
-} from "@cloudinary/transformation-builder-sdk/qualifiers/FontAntialias.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/FontAntialias";
 
 export {
   FontAntialias,

--- a/src/qualifiers/animatedFormat.ts
+++ b/src/qualifiers/animatedFormat.ts
@@ -1,4 +1,4 @@
-import { auto, gif, webp, png, AnimatedFormat } from "@cloudinary/transformation-builder-sdk/qualifiers/animatedFormat.js";
+import { auto, gif, webp, png, AnimatedFormat } from "@cloudinary/transformation-builder-sdk/qualifiers/animatedFormat";
 
 export {auto, gif, webp, png, AnimatedFormat};
 

--- a/src/qualifiers/artisticFilter.ts
+++ b/src/qualifiers/artisticFilter.ts
@@ -21,7 +21,7 @@ import {
   ukulele,
   frost,
   zorro
-} from "@cloudinary/transformation-builder-sdk/qualifiers/artisticFilter.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/artisticFilter";
 
 export {
   ArtisticFilter,

--- a/src/qualifiers/aspectRatio.ts
+++ b/src/qualifiers/aspectRatio.ts
@@ -1,5 +1,5 @@
 import { ar1X1, ar5X4, ar3X1, ar3X2, ar4X3, ar16X9, ignoreInitialAspectRatio, AspectRatio }
-  from "@cloudinary/transformation-builder-sdk/qualifiers/aspectRatio.js";
+  from "@cloudinary/transformation-builder-sdk/qualifiers/aspectRatio";
 
 
 export {ar1X1, ar5X4, ar3X1, ar3X2, ar4X3, ar16X9, ignoreInitialAspectRatio, AspectRatio};

--- a/src/qualifiers/audioCodec.ts
+++ b/src/qualifiers/audioCodec.ts
@@ -5,7 +5,7 @@ import {
   opus,
   none,
   vorbis
-} from "@cloudinary/transformation-builder-sdk/qualifiers/audioCodec.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/audioCodec";
 
 
 export {

--- a/src/qualifiers/audioFrequency.ts
+++ b/src/qualifiers/audioFrequency.ts
@@ -15,7 +15,7 @@ import {
   FREQ176400,
   FREQ192000,
   ORIGINAL
-} from "@cloudinary/transformation-builder-sdk/qualifiers/audioFrequency.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/audioFrequency";
 
 export {
   AudioFrequency,

--- a/src/qualifiers/autoFocus.ts
+++ b/src/qualifiers/autoFocus.ts
@@ -1,3 +1,3 @@
-import { AutoFocus } from "@cloudinary/transformation-builder-sdk/qualifiers/autoFocus.js";
+import { AutoFocus } from "@cloudinary/transformation-builder-sdk/qualifiers/autoFocus";
 
 export {AutoFocus};

--- a/src/qualifiers/background.ts
+++ b/src/qualifiers/background.ts
@@ -7,7 +7,7 @@ import {
   color,
   blurred,
   Background
-} from "@cloudinary/transformation-builder-sdk/qualifiers/background.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/background";
 
 export {
   auto,

--- a/src/qualifiers/blendMode.ts
+++ b/src/qualifiers/blendMode.ts
@@ -5,7 +5,7 @@ import {
   overlay,
   mask,
   antiRemoval
-} from "@cloudinary/transformation-builder-sdk/qualifiers/blendMode.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/blendMode";
 
 export {
   BlendMode,

--- a/src/qualifiers/chromaSubSampling.ts
+++ b/src/qualifiers/chromaSubSampling.ts
@@ -2,7 +2,7 @@ import {
   ChromaSubSampling,
   chroma420,
   chroma444
-} from "@cloudinary/transformation-builder-sdk/qualifiers/chromaSubSampling.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/chromaSubSampling";
 
 export {
   ChromaSubSampling,

--- a/src/qualifiers/color.ts
+++ b/src/qualifiers/color.ts
@@ -1,4 +1,4 @@
-import { Color } from "@cloudinary/transformation-builder-sdk/qualifiers/color.js";
+import { Color } from "@cloudinary/transformation-builder-sdk/qualifiers/color";
 
 export {Color};
 export type SystemColors = keyof typeof Color | string;

--- a/src/qualifiers/compass.ts
+++ b/src/qualifiers/compass.ts
@@ -9,7 +9,7 @@ import {
   southEast,
   southWest,
   northEast
-} from "@cloudinary/transformation-builder-sdk/qualifiers/compass.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/compass";
 
 export {
   Compass,

--- a/src/qualifiers/concatenate.ts
+++ b/src/qualifiers/concatenate.ts
@@ -1,2 +1,2 @@
-import {Concatenate, imageSource, videoSource, fetchSource} from "@cloudinary/transformation-builder-sdk/qualifiers/concatenate.js";
+import {Concatenate, imageSource, videoSource, fetchSource} from "@cloudinary/transformation-builder-sdk/qualifiers/concatenate";
 export {Concatenate, imageSource, videoSource, fetchSource};

--- a/src/qualifiers/gradientDirection/GradientDirectionQualifierValue.ts
+++ b/src/qualifiers/gradientDirection/GradientDirectionQualifierValue.ts
@@ -1,4 +1,4 @@
 import { GradientDirectionQualifierValue }
-  from "@cloudinary/transformation-builder-sdk/qualifiers/gradientDirection/GradientDirectionQualifierValue.js";
+  from "@cloudinary/transformation-builder-sdk/qualifiers/gradientDirection/GradientDirectionQualifierValue";
 
 export {GradientDirectionQualifierValue};

--- a/src/qualifiers/shakeStrength.ts
+++ b/src/qualifiers/shakeStrength.ts
@@ -4,7 +4,7 @@ import {
   pixels48,
   pixels64,
   ShakeStrength
-} from "@cloudinary/transformation-builder-sdk/qualifiers/shakeStrength.js";
+} from "@cloudinary/transformation-builder-sdk/qualifiers/shakeStrength";
 
 export {
   pixels16,

--- a/src/qualifiers/timeline.ts
+++ b/src/qualifiers/timeline.ts
@@ -1,3 +1,3 @@
-import {Timeline, position} from "@cloudinary/transformation-builder-sdk/qualifiers/timeline.js";
+import {Timeline, position} from "@cloudinary/transformation-builder-sdk/qualifiers/timeline";
 export {Timeline, position};
 

--- a/src/simpleTypes.ts
+++ b/src/simpleTypes.ts
@@ -1,3 +1,3 @@
-import {ExpressionQualifier} from "@cloudinary/transformation-builder-sdk/qualifiers/expression/ExpressionQualifier.js";
+import {ExpressionQualifier} from "@cloudinary/transformation-builder-sdk/qualifiers/expression/ExpressionQualifier";
 
 export type StringOrExpression = string | ExpressionQualifier;


### PR DESCRIPTION
This pr addresses https://github.com/cloudinary/js-url-gen/issues/533
1. Removed .js from transformation-builder-sdk imports
2. Added dist test