### PR TITLE
enable passing query params to URLConfig

### DIFF
--- a/__TESTS__/unit/url/url.test.ts
+++ b/__TESTS__/unit/url/url.test.ts
@@ -94,4 +94,16 @@ describe('Tests for URL configuration', () => {
 
     expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/s--${signature}--/c_crop,w_100/sample`);
   });
+
+  it('Should include query params', function () {
+    const image = createNewImage('sample', {cloudName: 'demo'}, {queryParams: {"_i": "abcde", "_z": 1234}});
+    const url = image.toURL();
+    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_z=1234`);
+  });
+
+  it('Should include query params with analytics', function () {
+    const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, queryParams: {"_i": "abcde"}});
+    const url = image.toURL();
+    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_a=E`);
+  });
 });

--- a/__TESTS__/unit/url/url.test.ts
+++ b/__TESTS__/unit/url/url.test.ts
@@ -96,13 +96,13 @@ describe('Tests for URL configuration', () => {
   });
 
   it('Should include query params', function () {
-    const image = createNewImage('sample', {cloudName: 'demo'}, {urlSearchParams: {"_i": "abcde", "_z": 1234, "_t": false}});
+    const image = createNewImage('sample', {cloudName: 'demo'}, {queryParams: {"_i": "abcde", "_z": 1234, "_t": false}});
     const url = image.toURL();
     expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_z=1234&_t=false`);
   });
 
   it('Should include query params with analytics', function () {
-    const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, urlSearchParams: {"_i": "abcde"}});
+    const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, queryParams: {"_i": "abcde"}});
     const url = image.toURL();
     expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_a=E`);
   });

--- a/__TESTS__/unit/url/url.test.ts
+++ b/__TESTS__/unit/url/url.test.ts
@@ -103,7 +103,12 @@ describe('Tests for URL configuration', () => {
 
   it('Should include query params with analytics', function () {
     const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, queryParams: {"_i": "abcde"}});
-    const url = image.toURL();
-    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_a=E`);
+    const analyticsOptions = {
+      techVersion: '16.0.0',
+      sdkCode: 'T',
+      sdkSemver: '1.0.0'
+    };
+    const url = image.toURL({trackedAnalytics: analyticsOptions});
+    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_a=ATAABAQ0`);
   });
 });

--- a/__TESTS__/unit/url/url.test.ts
+++ b/__TESTS__/unit/url/url.test.ts
@@ -96,13 +96,13 @@ describe('Tests for URL configuration', () => {
   });
 
   it('Should include query params', function () {
-    const image = createNewImage('sample', {cloudName: 'demo'}, {queryParams: {"_i": "abcde", "_z": 1234}});
+    const image = createNewImage('sample', {cloudName: 'demo'}, {urlSearchParams: {"_i": "abcde", "_z": 1234, "_t": false}});
     const url = image.toURL();
-    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_z=1234`);
+    expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_z=1234&_t=false`);
   });
 
   it('Should include query params with analytics', function () {
-    const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, queryParams: {"_i": "abcde"}});
+    const image = createNewImage('sample', {cloudName: 'demo'}, {analytics: true, urlSearchParams: {"_i": "abcde"}});
     const url = image.toURL();
     expect(url).toEqual(`https://res.cloudinary.com/demo/image/upload/sample?_i=abcde&_a=E`);
   });

--- a/__TESTS__/unit/urlConfig.test.ts
+++ b/__TESTS__/unit/urlConfig.test.ts
@@ -158,7 +158,7 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
       .setShorten(true)
       .setSignUrl(true)
       .setUseRootPath(true)
-      .setQueryParams({foo: 'bar'});
+      .setUrlSearchParams({foo: 'bar', baz: 111, dummy: true});
 
     expect(conf.cname).toBe('foo');
     expect(conf.forceVersion).toBe(true);
@@ -168,6 +168,6 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
     expect(conf.shorten).toBe(true);
     expect(conf.signUrl).toBe(true);
     expect(conf.useRootPath).toBe(true);
-    expect(conf.queryParams).toEqual({foo: 'bar'});
+    expect(conf.setUrlSearchParams).toEqual({foo: 'bar', baz: 111, dummy: true});
   });
 });

--- a/__TESTS__/unit/urlConfig.test.ts
+++ b/__TESTS__/unit/urlConfig.test.ts
@@ -168,6 +168,6 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
     expect(conf.shorten).toBe(true);
     expect(conf.signUrl).toBe(true);
     expect(conf.useRootPath).toBe(true);
-    expect(conf.setUrlSearchParams).toEqual({foo: 'bar', baz: 111, dummy: true});
+    expect(conf.urlSearchParams).toEqual({foo: 'bar', baz: 111, dummy: true});
   });
 });

--- a/__TESTS__/unit/urlConfig.test.ts
+++ b/__TESTS__/unit/urlConfig.test.ts
@@ -158,7 +158,7 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
       .setShorten(true)
       .setSignUrl(true)
       .setUseRootPath(true)
-      .setUrlSearchParams({foo: 'bar', baz: 111, dummy: true});
+      .setQueryParams({foo: 'bar', baz: 111, dummy: true});
 
     expect(conf.cname).toBe('foo');
     expect(conf.forceVersion).toBe(true);
@@ -168,6 +168,6 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
     expect(conf.shorten).toBe(true);
     expect(conf.signUrl).toBe(true);
     expect(conf.useRootPath).toBe(true);
-    expect(conf.urlSearchParams).toEqual({foo: 'bar', baz: 111, dummy: true});
+    expect(conf.queryParams).toEqual({foo: 'bar', baz: 111, dummy: true});
   });
 });

--- a/__TESTS__/unit/urlConfig.test.ts
+++ b/__TESTS__/unit/urlConfig.test.ts
@@ -157,7 +157,8 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
       .setSecure(true)
       .setShorten(true)
       .setSignUrl(true)
-      .setUseRootPath(true);
+      .setUseRootPath(true)
+      .setQueryParams({foo: 'bar'});
 
     expect(conf.cname).toBe('foo');
     expect(conf.forceVersion).toBe(true);
@@ -167,5 +168,6 @@ describe('It tests a combination of Cloudinary URL and Configuration', () => {
     expect(conf.shorten).toBe(true);
     expect(conf.signUrl).toBe(true);
     expect(conf.useRootPath).toBe(true);
+    expect(conf.queryParams).toEqual({foo: 'bar'});
   });
 });

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -283,10 +283,17 @@ class CloudinaryFile {
         .replace(/\?/g, '%3F')
         .replace(/=/g, '%3D');
 
+      const queryParams: Record<string, string | number> = this.urlConfig.queryParams || {};
+
       // urlConfig.analytics is true by default, has to be explicitly set to false to overwrite
       // Don't add analytics when publicId includes a '?' to not risk changing existing query params
       if (this.urlConfig.analytics !== false && !(publicID.includes('?'))) {
-        return `${safeURL}?_a=${getSDKAnalyticsSignature(trackedAnalytics)}`;
+        queryParams._a = getSDKAnalyticsSignature(trackedAnalytics);
+      }
+
+      const queryParamsStr = `${Object.entries(queryParams).map(([key, value]) => `${key}=${value}`).join('&')}`;
+      if (queryParamsStr) {
+        return `${safeURL}?${queryParamsStr}`;
       } else {
         return safeURL;
       }

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -283,17 +283,17 @@ class CloudinaryFile {
         .replace(/\?/g, '%3F')
         .replace(/=/g, '%3D');
 
-      const urlSearchParams = new URLSearchParams(this.urlConfig.urlSearchParams as Record<string, string>);
+      const queryParams = new URLSearchParams(this.urlConfig.queryParams as Record<string, string>);
 
       // urlConfig.analytics is true by default, has to be explicitly set to false to overwrite
       // Don't add analytics when publicId includes a '?' to not risk changing existing query params
       if (this.urlConfig.analytics !== false && !(publicID.includes('?'))) {
-        urlSearchParams.set("_a", getSDKAnalyticsSignature(trackedAnalytics));
+        queryParams.set("_a", getSDKAnalyticsSignature(trackedAnalytics));
       }
 
-      const searchParams = urlSearchParams.toString();
-      if (searchParams) {
-        return `${safeURL}?${searchParams}`;
+      const queryParamsString = queryParams.toString();
+      if (queryParamsString) {
+        return `${safeURL}?${queryParamsString}`;
       } else {
         return safeURL;
       }

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -283,17 +283,17 @@ class CloudinaryFile {
         .replace(/\?/g, '%3F')
         .replace(/=/g, '%3D');
 
-      const queryParams: Record<string, string | number> = this.urlConfig.queryParams || {};
+      const urlSearchParams = new URLSearchParams(this.urlConfig.urlSearchParams as Record<string, string>);
 
       // urlConfig.analytics is true by default, has to be explicitly set to false to overwrite
       // Don't add analytics when publicId includes a '?' to not risk changing existing query params
       if (this.urlConfig.analytics !== false && !(publicID.includes('?'))) {
-        queryParams._a = getSDKAnalyticsSignature(trackedAnalytics);
+        urlSearchParams.set("_a", getSDKAnalyticsSignature(trackedAnalytics));
       }
 
-      const queryParamsStr = `${Object.entries(queryParams).map(([key, value]) => `${key}=${value}`).join('&')}`;
-      if (queryParamsStr) {
-        return `${safeURL}?${queryParamsStr}`;
+      const searchParams = urlSearchParams.toString();
+      if (searchParams) {
+        return `${safeURL}?${searchParams}`;
       } else {
         return safeURL;
       }

--- a/src/config/URLConfig.ts
+++ b/src/config/URLConfig.ts
@@ -13,6 +13,7 @@ class URLConfig extends Config implements IURLConfig {
   useRootPath?: boolean;
   secure?: boolean;
   forceVersion?: boolean;
+  queryParams?: Record<string, string | number>
 
   /**
    * @param {IURLConfig} userURLConfig
@@ -99,6 +100,14 @@ class URLConfig extends Config implements IURLConfig {
    */
   setForceVersion(value: boolean): this {
     this.forceVersion = value;
+    return this;
+  }
+
+  /**
+   * @param params Sets additional query params
+   */
+  setQueryParams(params: Record<string, string | number>):this {
+    this.queryParams = params;
     return this;
   }
 }

--- a/src/config/URLConfig.ts
+++ b/src/config/URLConfig.ts
@@ -13,7 +13,7 @@ class URLConfig extends Config implements IURLConfig {
   useRootPath?: boolean;
   secure?: boolean;
   forceVersion?: boolean;
-  queryParams?: Record<string, string | number>
+  urlSearchParams?: Record<string, string | number | boolean>;
 
   /**
    * @param {IURLConfig} userURLConfig
@@ -104,10 +104,10 @@ class URLConfig extends Config implements IURLConfig {
   }
 
   /**
-   * @param params Sets additional query params
+   * @param params Sets additional params
    */
-  setQueryParams(params: Record<string, string | number>):this {
-    this.queryParams = params;
+  setUrlSearchParams(params: Record<string, string | number | boolean>):this {
+    this.urlSearchParams = params;
     return this;
   }
 }

--- a/src/config/URLConfig.ts
+++ b/src/config/URLConfig.ts
@@ -13,7 +13,7 @@ class URLConfig extends Config implements IURLConfig {
   useRootPath?: boolean;
   secure?: boolean;
   forceVersion?: boolean;
-  urlSearchParams?: Record<string, string | number | boolean>;
+  queryParams?: Record<string, string | number | boolean>;
 
   /**
    * @param {IURLConfig} userURLConfig
@@ -106,8 +106,8 @@ class URLConfig extends Config implements IURLConfig {
   /**
    * @param params Sets additional params
    */
-  setUrlSearchParams(params: Record<string, string | number | boolean>):this {
-    this.urlSearchParams = params;
+  setQueryParams(params: Record<string, string | number | boolean>):this {
+    this.queryParams = params;
     return this;
   }
 }

--- a/src/config/interfaces/Config/IURLConfig.ts
+++ b/src/config/interfaces/Config/IURLConfig.ts
@@ -13,6 +13,7 @@
  * @prop {boolean} [secure]
  * @prop {boolean} [forceVersion]
  * @prop {boolean} [analytics]
+ * @prop {object} [additionalQueryParams]
  * @example
  * import Cloudinary from '@cloudinary/url-gen';
  * // The Cloudinary Instance accepts a URLConfig under the `url` key
@@ -93,6 +94,11 @@ interface IURLConfig {
    * Whether or not to force a version
    */
   forceVersion?: boolean;
+
+  /**
+   * Additional query params to be added to the URL
+   */
+  queryParams?: Record<string, string | number>
 }
 
 export default IURLConfig;

--- a/src/config/interfaces/Config/IURLConfig.ts
+++ b/src/config/interfaces/Config/IURLConfig.ts
@@ -13,7 +13,7 @@
  * @prop {boolean} [secure]
  * @prop {boolean} [forceVersion]
  * @prop {boolean} [analytics]
- * @prop {object} [urlSearchParams]
+ * @prop {object} [queryParams]
  * @example
  * import Cloudinary from '@cloudinary/url-gen';
  * // The Cloudinary Instance accepts a URLConfig under the `url` key
@@ -98,7 +98,7 @@ interface IURLConfig {
   /**
    * Additional params to be added to the URL
    */
-  urlSearchParams?: Record<string, string | number | boolean>
+  queryParams?: Record<string, string | number | boolean>
 }
 
 export default IURLConfig;

--- a/src/config/interfaces/Config/IURLConfig.ts
+++ b/src/config/interfaces/Config/IURLConfig.ts
@@ -13,7 +13,7 @@
  * @prop {boolean} [secure]
  * @prop {boolean} [forceVersion]
  * @prop {boolean} [analytics]
- * @prop {object} [additionalQueryParams]
+ * @prop {object} [urlSearchParams]
  * @example
  * import Cloudinary from '@cloudinary/url-gen';
  * // The Cloudinary Instance accepts a URLConfig under the `url` key
@@ -96,9 +96,9 @@ interface IURLConfig {
   forceVersion?: boolean;
 
   /**
-   * Additional query params to be added to the URL
+   * Additional params to be added to the URL
    */
-  queryParams?: Record<string, string | number>
+  urlSearchParams?: Record<string, string | number | boolean>
 }
 
 export default IURLConfig;

--- a/src/internal/internalConstants.ts
+++ b/src/internal/internalConstants.ts
@@ -16,7 +16,8 @@ export const ALLOWED_URL_CONFIG = [
   'useRootPath',
   'secure',
   'forceVersion',
-  'analytics'
+  'analytics',
+  'queryParams'
 ];
 
 /**

--- a/src/internal/internalConstants.ts
+++ b/src/internal/internalConstants.ts
@@ -17,7 +17,7 @@ export const ALLOWED_URL_CONFIG = [
   'secure',
   'forceVersion',
   'analytics',
-  'queryParams'
+  'urlSearchParams'
 ];
 
 /**

--- a/src/internal/internalConstants.ts
+++ b/src/internal/internalConstants.ts
@@ -17,7 +17,7 @@ export const ALLOWED_URL_CONFIG = [
   'secure',
   'forceVersion',
   'analytics',
-  'urlSearchParams'
+  'queryParams'
 ];
 
 /**


### PR DESCRIPTION
### Pull request for @cloudinary/url-gen


#### What does this PR solve?
Add the ability to provide additional query params to be added to the final generated URL


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
